### PR TITLE
Problem: typo in libzyre git specification

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -27,7 +27,7 @@ if [ $BUILD_TYPE == "default" ]; then
     git clone --depth 1 https://github.com/zeromq/malamute malamute
     ( cd malamute && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make install ) || exit 1
 
-    git clone --depth 1 https://github.com/zeromq/libzyre libzyre
+    git clone --depth 1 https://github.com/zeromq/zyre libzyre
     ( cd libzyre && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make install ) || exit 1
 
     # Build and check this project


### PR DESCRIPTION
Solution: renamed .../zeromq/libzyre to .../zeromq/zyre in git
specification so CI script will be able to get source for integration.
